### PR TITLE
Analpa 3839 update tietok backend os packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-#Tomcat 7 poimittu projektin pom:sta ja openjdk8 confluencesta tuotannon ajoympariston kuvauksesta
 FROM tomcat:7.0.109-jdk8-adoptopenjdk-openj9
 
 RUN apt update && apt upgrade --quiet --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 #Tomcat 7 poimittu projektin pom:sta ja openjdk8 confluencesta tuotannon ajoympariston kuvauksesta
-FROM tomcat:7-jdk8-openjdk
+FROM tomcat:7.0.109-jdk8-adoptopenjdk-openj9
+
+RUN apt update && apt upgrade --quiet --yes
 
 # Remove default apps
 RUN rm -rf {$CATALINA_HOME}/webapps/*

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -1,6 +1,8 @@
 #Tomcat 7 poimittu projektin pom:sta ja openjdk8 confluencesta tuotannon ajoympariston kuvauksesta
 #AWS ecr osoite vain pilvikayttoon, devissa voi poistaa (tai tehda toisen Dockerfilen)
-FROM 894932018761.dkr.ecr.eu-west-1.amazonaws.com/tomcat:7-jdk8-openjdk
+FROM 894932018761.dkr.ecr.eu-west-1.amazonaws.com/tomcat:7.0.109-jdk8-adoptopenjdk-openj9
+
+RUN apt update && apt upgrade --quiet --yes
 
 # Remove default apps
 RUN rm -rf {$CATALINA_HOME}/webapps/*

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -1,4 +1,3 @@
-#Tomcat 7 poimittu projektin pom:sta ja openjdk8 confluencesta tuotannon ajoympariston kuvauksesta
 #AWS ecr osoite vain pilvikayttoon, devissa voi poistaa (tai tehda toisen Dockerfilen)
 FROM 894932018761.dkr.ecr.eu-west-1.amazonaws.com/tomcat:7.0.109-jdk8-adoptopenjdk-openj9
 

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -9,5 +9,3 @@ RUN rm -rf {$CATALINA_HOME}/webapps/*
 
 # Copy and extract
 ADD target/TietokatalogiUI.war ${CATALINA_HOME}/webapps/tietokatalogi.war
-
-ENV CATALINA_OPTS="-Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog -Dorg.apache.commons.logging.simplelog.showdatetime=true -Dorg.apache.commons.logging.simplelog.log.org.apache.http=DEBUG -Dorg.apache.commons.logging.simplelog.log.org.apache.http.wire=ERROR"


### PR DESCRIPTION
Reduce container vulnerabilities by changing baseimage (shows fewer vunlerabilities on dockerhub) and installing new packages in docker build script. After both of these, the built backend image should have 0 critical OS package vulnerabilities according to a local scan that I ran.

Also, pushed the changed baseimage to our aws ecr so the new image should work in our aws pipeline where we build the dev and prod versions.

To test:
build containers and run using docker-compose as shown in `tietokatalogi-backend/README.md` and `tietokatalogi-frontend/README.md` and use the app. Should work as normal.